### PR TITLE
Provide an empty prefix to sed so the command works in BSD sed

### DIFF
--- a/java/jsinterop/base/BUILD
+++ b/java/jsinterop/base/BUILD
@@ -36,7 +36,7 @@ genrule(
     srcs = glob(["**/*.java"]),
     outs = ["base-j2cl.srcjar"],
     cmd = "\n".join([
-        "sed -i 's/\/\/J2CL_ONLY\ //g' $(SRCS)",
+        "sed -i '' 's/\/\/J2CL_ONLY\ //g' $(SRCS)",
         "$(location //third_party:zip) c $@ $(SRCS)",
     ]),
     tools = ["//third_party:zip"],


### PR DESCRIPTION
The BSD build of sed expects that the next string is an argument, and this sed operation fails with

```
sed: 1: "java/jsinterop/base/Any ...": invalid command code j
```

It is my understanding that this change should be compatible on both linux and os x this way, tested on both platforms via `bazel build //java/...` (though Java >8 was required on linux).