### PR TITLE
Fix build on macOS which was broken since sed doesn't support in-place

### DIFF
--- a/java/jsinterop/base/BUILD
+++ b/java/jsinterop/base/BUILD
@@ -35,7 +35,7 @@ genrule(
     srcs = glob(["**/*.java"]),
     outs = ["base-j2cl.srcjar"],
     cmd = "\n".join([
-        "sed -i.bak 's|// J2CL_ONLY ||g' $(SRCS)",
+        "perl -i.bak -pe 's|// J2CL_ONLY ||g' $(SRCS)",
         "$(location //third_party:zip) c $@ $(SRCS)",
     ]),
     tools = ["//third_party:zip"],


### PR DESCRIPTION
Fix build on macOS which was broken since sed doesn't support in-place editing of sym links

See issue #16 

Using perl seems to have better cross-platform support.